### PR TITLE
Add scrapy-autoextract to Pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 
 matrix:
   include:
+    - python: 3.5
+      env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ matrix:
 install: pip install -U tox
 
 # command to run tests
-script: tox
+script:
+  - tox -e flake8
+  - tox
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+
+install:
+  - pip install -U -r test/requirements.txt
+
+script:
+  - flake8 scrapy_autoextract
+  - pytest -ra -sv test
+
+deploy:
+  provider: pypi
+  user: scrapinghub
+  password:
+    secure: ...
+  on:
+    tags: true
+    repo: scrapinghub/scrapy-autoextract

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 language: python
 
-install:
-- pip install -U -r test/requirements.txt
+matrix:
+  include:
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+      dist: xenial
 
-script:
-- flake8 scrapy_autoextract
-- pytest -ra -sv test
+# command to install dependencies
+install: pip install -U tox
+
+# command to run tests
+script: tox
 
 deploy:
   provider: pypi
@@ -16,3 +23,4 @@ deploy:
   on:
     tags: true
     repo: scrapinghub/scrapy-autoextract
+    condition: $TOXENV == py37

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,14 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
-      dist: xenial
+    - python: 3.7
+      env: TOXENV=flake8
 
 # command to install dependencies
 install: pip install -U tox
 
 # command to run tests
-script:
-  - tox -e flake8
-  - tox
+script: tox
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
 language: python
 
 install:
-  - pip install -U -r test/requirements.txt
+- pip install -U -r test/requirements.txt
 
 script:
-  - flake8 scrapy_autoextract
-  - pytest -ra -sv test
+- flake8 scrapy_autoextract
+- pytest -ra -sv test
 
 deploy:
   provider: pypi
-  user: scrapinghub
+  user: "__token__"
+  distributions: "sdist bdist_wheel"
   password:
-    secure: ...
+    secure: c7Qq/nEX4bJtZOhNpBG0Vp9ypttrP1MmcgFtIRsyXe6TnCOBZrmNgmvVrOtdXNBhlB7gktZRMSJ6SEYz1fC7JHwI+IyIoTjSbc6WlfcyMjnrd0V6BONKBJ2qBqCB50/nIgP7OVS+js6xXXmkOg/dKkvJUDK/s56cQoTXeIvJonWl7Krg6pGdmMZSLQwxzZ/IwtlVMHsGmrChnCIsPiw1V2bYXOjVcGxAc3v83lCg+mSMG4UYu+wMAeNt5IkZMsQL/kmGZchJNc4h0dzSCCK76DmKvwHRahSzF5AWZ/aaolRgnaxL11/P4N/3VqFfUjQEfrEgdB00EyxeS2I3PFXz++7dsLPbbzwE+QB6qhtNld2u1uVhLZv9NtjOcivPy3yGmiczjUasQSf3o/Ec6C7eZpKLaY2blsk8a9lHNAbgUOuuCP0e/ThZa1gNEvQENmPMgTTKzuSu0Rc+YmA8Nthw3unuslWxOanLrqJLFwxt6dy+vTkHG2jcqq9Cx8KA0e6lRsFjTGzOgkjrcV7kvj/wr1eoClQQX7c9LeMHwn+aNeVf535Y//dcio8M7gheSur8DXV5Hm7rN9vB6x0t/tcvXGUnTAMRi0GMksoNBQhcmg08Jd2vyXw5sxgms9ogkQcWJSN/B1He2nl0BLRykx2lNkrSk9n6/wX3r8lJBkpHgrQ=
   on:
     tags: true
     repo: scrapinghub/scrapy-autoextract

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,16 @@ The middleware adds the result of AutoExtract to ``response.meta['autoextract']`
 for consumption by the spider.
 
 
+Installation
+===========
+
+::
+
+    pip install scrapy-autoextract
+
+scrapy-autoextract requires Python 3.
+
+
 Configuration
 =============
 1. Add the AutoExtract downloader middleware in the settings file::

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Installation
 
     pip install scrapy-autoextract
 
-scrapy-autoextract requires Python 3.
+scrapy-autoextract requires Python 3.5+
 
 
 Configuration

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Configuration
 1. Add the AutoExtract downloader middleware in the settings file::
 
     DOWNLOADER_MIDDLEWARES = {
-        'scrapy_autoextract.middlewares.AutoExtractMiddleware': 543,
+        'scrapy_autoextract.AutoExtractMiddleware': 543,
     }
 
 Note that this should be the last downloader middleware to be executed.

--- a/scrapy_autoextract/__init__.py
+++ b/scrapy_autoextract/__init__.py
@@ -1,0 +1,1 @@
+from .middlewares import AutoExtractMiddleware  # noqa: F401

--- a/scrapy_autoextract/middlewares.py
+++ b/scrapy_autoextract/middlewares.py
@@ -145,7 +145,7 @@ class AutoExtractMiddleware(object):
         url = request.meta[AUTOEXTRACT_META_KEY]['original_url']
 
         try:
-            result = json.loads(response.body)[0]
+            result = json.loads(response.body.decode('utf8'))[0]
         except Exception:
             self.inc_metric('autoextract/errors/json_decode')
             raise AutoExtractError('Cannot parse JSON response from AutoExtract'

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,3 @@
+flake8
+pytest
+mock

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,3 @@
 scrapy
 flake8
 pytest
-mock

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,4 @@
+scrapy
 flake8
 pytest
 mock

--- a/test/test_autoextract.py
+++ b/test/test_autoextract.py
@@ -65,7 +65,8 @@ def _assert_enabled(spider,
     assert out.meta['autoextract'].get('enabled')
     assert out.headers.get('Authorization') == api_auth
 
-    resp = Response(out.url, request=out, body=b'[{}]')
+    resp = Response(out.url, request=out)
+    resp._body = '[{}]'  # workaround to make the body work with Python 3.5+
     proc = mw.process_response(out, resp, spider)
     assert proc.meta['autoextract'].get('original_url') == url
     assert isinstance(proc.meta['autoextract'].get('article'), dict)

--- a/test/test_autoextract.py
+++ b/test/test_autoextract.py
@@ -1,0 +1,95 @@
+import os
+import sys
+import pytest
+
+from w3lib.http import basic_auth_header
+from scrapy.http import Request, Response
+from scrapy.spiders import Spider
+from scrapy.utils.test import get_crawler
+
+sys.path.append(os.getcwd())
+from scrapy_autoextract import AutoExtractMiddleware
+from scrapy_autoextract.middlewares import AutoExtractConfigError
+
+AUTOX_META = {'autoextract': {'enabled': True}}
+
+MW_SETTINGS = {
+    'AUTOEXTRACT_USER': 'apikey',
+    'AUTOEXTRACT_PAGE_TYPE': 'article',
+}
+
+
+def setup_module(module):
+    global spider
+    spider = Spider('spidr')
+
+
+def _mock_crawler(spider, settings=None):
+
+    class MockedDownloader:
+        slots = {}
+
+        def _get_slot_key(self, a, b):
+            return str(a) + str(b)
+
+    class MockedEngine:
+        downloader = MockedDownloader()
+        fake_spider_closed_result = None
+
+        def close_spider(self, spider, reason):
+            self.fake_spider_closed_result = (spider, reason)
+
+    # with `spider` instead of `type(spider)` raises an exception
+    crawler = get_crawler(type(spider), settings)
+    crawler.engine = MockedEngine()
+    return crawler
+
+
+def _assert_disabled(spider, settings=None):
+    crawler = _mock_crawler(spider, settings)
+    mw = AutoExtractMiddleware.from_crawler(crawler)
+    req = Request('http://quotes.toscrape.com', meta=AUTOX_META)
+    out = mw.process_request(req, spider)
+    assert out is None
+    assert req.meta.get('autoextract') is None
+    res = Response(req.url, request=req)
+    assert mw.process_response(req, res, spider) == res
+
+
+def _assert_enabled(spider,
+                    settings=None,
+                    url='http://quotes.toscrape.com',
+                    proxyurl='autoextract.scrapinghub.com',
+                    proxyauth=basic_auth_header('apikey', '')):
+    crawler = _mock_crawler(spider, settings)
+    mw = AutoExtractMiddleware.from_crawler(crawler)
+
+    req = Request(url, meta=AUTOX_META)
+    out = mw.process_request(req, spider)
+    assert proxyurl in out.url
+    assert out.meta['autoextract'].get('enabled')
+    assert out.headers.get('Authorization') == proxyauth
+
+    resp = Response(out.url, request=out, body=b'[{}]')
+    proc = mw.process_response(out, resp, spider)
+    assert proc.meta['autoextract'].get('original_url') == url
+    assert isinstance(proc.meta['autoextract'].get('article'), dict)
+
+
+def test_bad_config():
+    with pytest.raises(AutoExtractConfigError):
+        _assert_disabled(spider, {})
+    with pytest.raises(AutoExtractConfigError):
+        _assert_disabled(spider, {'AUTOEXTRACT_USER': 'apikey'})
+
+
+def test_disabled():
+    crawler = _mock_crawler(spider, MW_SETTINGS)
+    mw = AutoExtractMiddleware.from_crawler(crawler)
+    req = Request('http://quotes.toscrape.com', meta={'autoextract': {}})
+    out = mw.process_request(req, spider)
+    assert out is None
+
+
+def test_enabled():
+    _assert_enabled(spider, MW_SETTINGS)

--- a/test/test_autoextract.py
+++ b/test/test_autoextract.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import pytest
 
 from w3lib.http import basic_auth_header
@@ -7,7 +5,6 @@ from scrapy.http import Request, Response
 from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
 
-sys.path.append(os.getcwd())
 from scrapy_autoextract import AutoExtractMiddleware
 from scrapy_autoextract.middlewares import AutoExtractConfigError
 
@@ -58,15 +55,15 @@ def _assert_disabled(spider, settings=None):
 def _assert_enabled(spider,
                     settings=None,
                     url='http://quotes.toscrape.com',
-                    proxyurl='autoextract.scrapinghub.com',
-                    proxyauth=basic_auth_header('apikey', '')):
+                    api_url='autoextract.scrapinghub.com',
+                    api_auth=basic_auth_header('apikey', '')):
     mw = _mock_mw(spider, settings)
 
     req = Request(url, meta=AUTOX_META)
     out = mw.process_request(req, spider)
-    assert proxyurl in out.url
+    assert api_url in out.url
     assert out.meta['autoextract'].get('enabled')
-    assert out.headers.get('Authorization') == proxyauth
+    assert out.headers.get('Authorization') == api_auth
 
     resp = Response(out.url, request=out, body=b'[{}]')
     proc = mw.process_response(out, resp, spider)

--- a/test/test_autoextract.py
+++ b/test/test_autoextract.py
@@ -99,9 +99,9 @@ def test_timeout():
     assert out is not None
     assert out.meta['download_timeout'] >= 180
 
-    config['AUTOEXTRACT_TIMEOUT'] = 10_000
+    config['AUTOEXTRACT_TIMEOUT'] = 10000
     mw = _mock_mw(spider, config)
     req = Request('http://quotes.toscrape.com', meta=AUTOX_META)
     out = mw.process_request(req, spider)
     assert out is not None
-    assert out.meta['download_timeout'] == 10_000
+    assert out.meta['download_timeout'] == 10000

--- a/test/test_autoextract.py
+++ b/test/test_autoextract.py
@@ -65,8 +65,7 @@ def _assert_enabled(spider,
     assert out.meta['autoextract'].get('enabled')
     assert out.headers.get('Authorization') == api_auth
 
-    resp = Response(out.url, request=out)
-    resp._body = '[{}]'  # workaround to make the body work with Python 3.5+
+    resp = Response(out.url, request=out, body=b'[{}]')
     proc = mw.process_response(out, resp, spider)
     assert proc.meta['autoextract'].get('original_url') == url
     assert isinstance(proc.meta['autoextract'].get('article'), dict)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37
+envlist = py35, py36, py37
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py36, py37
+
+[testenv]
+deps =
+    scrapy
+    flake8
+    pytest
+    mock
+
+commands =
+    flake8 scrapy_autoextract
+    pytest -ra -sv {posargs:test}

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,7 @@ envlist = py36, py37
 
 [testenv]
 deps =
-    scrapy
-    flake8
-    pytest
-    mock
+    -r test/requirements.txt
 
 commands =
     flake8 scrapy_autoextract

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,8 @@ deps =
     -r test/requirements.txt
 
 commands =
-    flake8 scrapy_autoextract
     pytest -ra -sv {posargs:test}
+
+[testenv:flake8]
+commands =
+    flake8 scrapy_autoextract


### PR DESCRIPTION
This PR:

* adds a few basic tests for the middleware
* use tox to test agains multiple Python versions
* adds Travis CI integration to publish tags on Pypi automatically
