### PR TITLE
Better error catching for Request-level API errors

### DIFF
--- a/scrapy_autoextract/middlewares.py
+++ b/scrapy_autoextract/middlewares.py
@@ -157,15 +157,16 @@ class AutoExtractMiddleware(object):
             raise AutoExtractError('Cannot parse JSON response from AutoExtract'
                                    ' for {}: {}'.format(url, response.body))
 
+        if response.status != 200:
+            self.inc_metric('autoextract/errors/response_error')
+            raise AutoExtractError('Received error from AutoExtract for '
+                                   '{}: {}'.format(url, response_object))
+
         result = None
         if isinstance(response_object, list):
             result = response_object[0]
-        elif isinstance(response_object, dict):
-            self.inc_metric('autoextract/errors/result_error')
-            raise AutoExtractError('Received error from AutoExtract for '
-                                   '{}: {}'.format(url, response_object))
         else:
-            self.inc_metric('autoextract/errors/result_error')
+            self.inc_metric('autoextract/errors/type_error')
             raise AutoExtractError('Received invalid response from AutoExtract for '
                                    '{}: {}'.format(url, response_object))
 

--- a/scrapy_autoextract/middlewares.py
+++ b/scrapy_autoextract/middlewares.py
@@ -158,7 +158,7 @@ class AutoExtractMiddleware(object):
                                    ' for {}: {}'.format(url, response.body))
 
         if response.status != 200:
-            self.inc_metric('autoextract/errors/response_error')
+            self.inc_metric('autoextract/errors/response_error/{}'.format(response.status))
             raise AutoExtractError('Received error from AutoExtract for '
                                    '{}: {}'.format(url, response_object))
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'Operating System :: OS Independent',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Framework :: Scrapy',

--- a/test/test_autoextract.py
+++ b/test/test_autoextract.py
@@ -8,7 +8,7 @@ from scrapy.spiders import Spider
 from scrapy.utils.test import get_crawler
 
 from scrapy_autoextract import AutoExtractMiddleware
-from scrapy_autoextract.middlewares import AutoExtractConfigError
+from scrapy_autoextract.middlewares import AutoExtractError, AutoExtractConfigError
 
 AUTOX_META = {'autoextract': {'enabled': True}}
 
@@ -89,6 +89,17 @@ def test_disabled():
 
 def test_enabled():
     _assert_enabled(spider, MW_SETTINGS)
+
+
+def test_request_error():
+    mw = _mock_mw(spider, MW_SETTINGS)
+    req = Request('http://quotes.toscrape.com', meta=AUTOX_META)
+
+    out = mw.process_request(req, spider)
+    err = b'{"title":"No authentication token provided","type":"http://errors.xod.scrapinghub.com/unauthorized.html"}'
+    resp = Response(out.url, request=out, body=err)
+    with pytest.raises(AutoExtractError):
+        mw.process_response(out, resp, spider)
 
 
 def test_timeout():


### PR DESCRIPTION
As the title sais. Also added a test.
The middleware already handles query level errors, but did not handle request level errors like: https://doc.scrapinghub.com/autoextract.html#id1
Request level errors are not lists, they are dictionaries and they used to crash and the error was not as clear as it could be.