### PR TITLE
Update docs about domain concurrency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,8 @@ Available settings:
   This is required for the AutoExtract classifier to know what kind of page needs to be extracted.
 - `extra` [optional] allows sending extra payload data to your AutoExtract request.
   Must be specified as ``{'autoextract': {'extra': {}}}`` request meta and must be a dict.
-
+- ``AUTOEXTRACT_SLOT_POLICY`` [optional] Download concurrency options. Defaults to ``SlotPolicy.PER_DOMAIN``
+  - If set to ``SlotPolicy.PER_DOMAIN``, then consider setting ``SCHEDULER_PRIORITY_QUEUE = 'scrapy.pqueues.DownloaderAwarePriorityQueue'`` to make better usage of AutoExtract concurrency and avoid delays
 
 Within the spider, consuming the AutoExtract result is as easy as::
 


### PR DESCRIPTION
@croqaz , it turns out that the code is fine to make best usage of `SCHEDULER_PRIORITY_QUEUE = 'scrapy.pqueues.DownloaderAwarePriorityQueue'`

Here it loads the slot
https://github.com/scrapy/scrapy/blob/master/scrapy/pqueues.py#L185
https://github.com/scrapy/scrapy/blob/master/scrapy/pqueues.py#L123

Which comes from `request.meta`
https://github.com/scrapy/scrapy/blob/master/scrapy/core/downloader/__init__.py#L109

And the middlewares sets it here
https://github.com/scrapinghub/scrapy-autoextract/blob/master/scrapy_autoextract/middlewares.py#L265

So, the slots are properly set.
Just need to set the proper Priority Queue in the project so it avoids concurrency delays in AutoExtract