### PR TITLE
Remove page-types check

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,8 @@ Available settings:
 - `extra` [optional] allows sending extra payload data to your AutoExtract request.
   Must be specified as ``{'autoextract': {'extra': {}}}`` request meta and must be a dict.
 - ``AUTOEXTRACT_SLOT_POLICY`` [optional] Download concurrency options. Defaults to ``SlotPolicy.PER_DOMAIN``
-  - If set to ``SlotPolicy.PER_DOMAIN``, then consider setting ``SCHEDULER_PRIORITY_QUEUE = 'scrapy.pqueues.DownloaderAwarePriorityQueue'`` to make better usage of AutoExtract concurrency and avoid delays
+  - If set to ``SlotPolicy.PER_DOMAIN``, then consider setting ``SCHEDULER_PRIORITY_QUEUE = 'scrapy.pqueues.DownloaderAwarePriorityQueue'``
+  to make better usage of AutoExtract concurrency and avoid delays.
 
 Within the spider, consuming the AutoExtract result is as easy as::
 

--- a/scrapy_autoextract/middlewares.py
+++ b/scrapy_autoextract/middlewares.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 AUTOEXTRACT_META_KEY = '_autoextract_processed'
 USER_AGENT = 'scrapy-autoextract/{} scrapy/{}'.format(__version__, scrapy.__version__)
-SUPPORTED_PAGETYPES = ('article', 'product', 'jobPosting')
 MAX_ERROR_BODY = 2000
 
 
@@ -257,8 +256,6 @@ class AutoExtractMiddleware(object):
         # and fallback to the value from middleware
         page_type = request.meta.get('autoextract', {}).get('pageType', self.page_type)
         if not page_type or not isinstance(page_type, str):
-            raise AutoExtractConfigError('Invalid pageType value: {}'.format(page_type))
-        if page_type not in SUPPORTED_PAGETYPES:
             raise AutoExtractConfigError('Invalid pageType value: {}'.format(page_type))
         return page_type
 


### PR DESCRIPTION
Remove this check because it's already done on the API server side.
This will allow to support other page-types in the future, without middleware changes.