### PR TITLE
Add AutoExtract HTML data provider

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -210,6 +210,8 @@ Provider settings
 - ``AUTOEXTRACT_USER`` [optional] is your AutoExtract API key. Defaults to ``SCRAPINGHUB_AUTOEXTRACT_KEY`` environment variable.
 - ``AUTOEXTRACT_URL`` [optional] the AutoExtract service url. Defaults to the official AutoExtract endpoint.
 - ``AUTOEXTRACT_MAX_QUERY_ERROR_RETRIES`` [optional] Max number of retries for Query-level errors. Defaults to ``3``.
+- ``AUTOEXTRACT_HTML_ARGUMENT`` [optional] Argument name used to specify if a request should return HTML data on its response.
+  By default, AutoExtract names this argument as "fullHtml". Probably, should not be set in production environments.
 
 Limitations
 ===========


### PR DESCRIPTION
This provider sets some extra params on Scrapy request that are checked by the providers when they're calling the AutoExtract API.

This makes it possible to fetch page's HTML in combination with a regular AutoExtract page type, for example, Articles or Products.

Example:

```python
    def parse(self, response: DummyResponse, article: AutoExtractArticleData, html: AutoExtractHTMLData):
        # your article should contain page's full HTML now
        html = article.data["html"]
```

In the future, it will be possible to avoid making multiple requests for grabbing different page types for the same URL. But for now, we should aim to at least avoid making an additional request to grab AutoExtractHTMLData when there's another page object – like AutoExtractArticleData – being fetched.