### PR TITLE
gzip compression for cache

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -242,6 +242,9 @@ Provider settings
   be placed in the ``.scrapy`` folder. File will be created if it doesn't exist.
   Cache is useful for development; AutoExtract requests bypass standard Scrapy
   cache when providers are used.
+- ``AUTOEXTRACT_CACHE_GZIP`` [optional] when True (default), cached AutoExtract
+  responses are compressed using gzip. Set this option to False to turn
+  compression off.
 
 Limitations
 ===========

--- a/scrapy_autoextract/providers.py
+++ b/scrapy_autoextract/providers.py
@@ -98,7 +98,8 @@ class AutoExtractProvider(PageObjectInputProvider):
         if cache_filename:
             cache_filename = os.path.join(get_scrapy_data_path(createdir=True),
                                           cache_filename)
-            self.cache = AutoExtractCache(cache_filename)
+            compressed = self.settings.getbool('AUTOEXTRACT_CACHE_GZIP', True)
+            self.cache = AutoExtractCache(cache_filename, compressed=compressed)
         else:
             self.cache = DummyCache()
 


### PR DESCRIPTION
This PR adds gzip compression for AutoExtract cache, and enables it by default.
